### PR TITLE
Add a couple more ampersand related tests to HotkeyTests

### DIFF
--- a/ManagedAutoHotkeyParser/Expressions/HotkeyExpression.cs
+++ b/ManagedAutoHotkeyParser/Expressions/HotkeyExpression.cs
@@ -117,8 +117,11 @@ namespace ManagedAutoHotkeyParser
 
                 string key2;
                 HotkeySymbolModifiers modifiers2;
+
                 // We subtract the hotkey token length from total length to get ignore the token
-                if (!TryParseHalf(hotkeys[1], hotkeys[1].Length - HotkeyExpression.HotkeyToken.Length, out key2, out modifiers2))
+                string hotkey2 = hotkeys[1].Substring(0, hotkeys[1].Length - HotkeyExpression.HotkeyToken.Length);
+
+                if (!TryParseHalf(hotkey2, hotkey2.Length, out key2, out modifiers2))
                 {
                     return false;
                 }
@@ -135,6 +138,11 @@ namespace ManagedAutoHotkeyParser
         {
             key = null;
             modifiers = HotkeySymbolModifiers.None;
+
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
 
             for (int i = 0; i < maxIndex; i++)
             {

--- a/UnitTests/ExpressionTests/HotkeyTests.cs
+++ b/UnitTests/ExpressionTests/HotkeyTests.cs
@@ -167,5 +167,27 @@ namespace UnitTests.ExpressionTests
             Assert.Equal(hkExpr.Key2, "m");
             Assert.Equal(hkExpr.Modifiers2, HotkeySymbolModifiers.Ctrl);
         }
+
+        [Fact]
+        public void TryParse_AmpersandWithBlankIsInvalid()
+        {
+            const string expressionString1 = "^k &::";
+            Expression expr;
+            Assert.False(HotkeyExpression.TryParse(expressionString1, out expr));
+            Assert.Null(expr);
+
+            const string expressionString2 = "& ^k::";
+            Assert.False(HotkeyExpression.TryParse(expressionString2, out expr));
+            Assert.Null(expr);
+        }
+
+        [Fact]
+        public void TryParse_MoreThanOneAmpersandIsInvalid()
+        {
+            const string expressionString = "^k & ^m & ^l";
+            Expression expr;
+            Assert.False(HotkeyExpression.TryParse(expressionString, out expr));
+            Assert.Null(expr);
+        }
     }
 }


### PR DESCRIPTION
Found a bug where strings like "^m & ::" would be allowed, so I've added
tests and fixed the issue.
